### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/Comment.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Comment.java
+++ b/src/main/java/com/scalesec/vulnado/Comment.java
@@ -1,6 +1,5 @@
 package com.scalesec.vulnado;
 
-import org.apache.catalina.Server;
 import java.sql.*;
 import java.util.Date;
 import java.util.List;
@@ -8,14 +7,16 @@ import java.util.ArrayList;
 import java.util.UUID;
 
 public class Comment {
-  public String id, username, body;
-  public Timestamp created_on;
+  private String id;
+  private String username;
+  private String body;
+  private Timestamp createdOn;
 
-  public Comment(String id, String username, String body, Timestamp created_on) {
+  public Comment(String id, String username, String body, Timestamp createdOn) {
     this.id = id;
     this.username = username;
     this.body = body;
-    this.created_on = created_on;
+    this.createdOn = createdOn;
   }
 
   public static Comment create(String username, String body){
@@ -23,7 +24,7 @@ public class Comment {
     Timestamp timestamp = new Timestamp(time);
     Comment comment = new Comment(UUID.randomUUID().toString(), username, body, timestamp);
     try {
-      if (comment.commit()) {
+      if (comment.commit().booleanValue()) {
         return comment;
       } else {
         throw new BadRequest("Unable to save comment");
@@ -33,29 +34,29 @@ public class Comment {
     }
   }
 
-  public static List<Comment> fetch_all() {
+  public static List<Comment> fetchAll() {
     Statement stmt = null;
-    List<Comment> comments = new ArrayList();
+    List<Comment> comments = new ArrayList<>();
     try {
       Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
+      try (Statement stmt = cxn.createStatement()) {
 
-      String query = "select * from comments;";
+      String query = "SELECT id, username, body, created_on FROM comments;";
       ResultSet rs = stmt.executeQuery(query);
       while (rs.next()) {
         String id = rs.getString("id");
         String username = rs.getString("username");
         String body = rs.getString("body");
-        Timestamp created_on = rs.getTimestamp("created_on");
+        Timestamp createdOn = rs.getTimestamp("created_on");
         Comment c = new Comment(id, username, body, created_on);
         comments.add(c);
       }
       cxn.close();
     } catch (Exception e) {
       e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
+      Logger logger = Logger.getLogger(Comment.class.getName());
+      logger.severe(e.getClass().getName() + ": " + e.getMessage());
     } finally {
-      return comments;
     }
   }
 
@@ -63,20 +64,19 @@ public class Comment {
     try {
       String sql = "DELETE FROM comments where id = ?";
       Connection con = Postgres.connection();
-      PreparedStatement pStatement = con.prepareStatement(sql);
+      try (PreparedStatement pStatement = con.prepareStatement(sql)) {
       pStatement.setString(1, id);
       return 1 == pStatement.executeUpdate();
     } catch(Exception e) {
       e.printStackTrace();
     } finally {
-      return false;
     }
   }
 
   private Boolean commit() throws SQLException {
     String sql = "INSERT INTO comments (id, username, body, created_on) VALUES (?,?,?,?)";
     Connection con = Postgres.connection();
-    PreparedStatement pStatement = con.prepareStatement(sql);
+    try (PreparedStatement pStatement = con.prepareStatement(sql)) {
     pStatement.setString(1, this.id);
     pStatement.setString(2, this.username);
     pStatement.setString(3, this.body);


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 96b315703c400ab7041e17511d079800e78c73d6

**Description:** The pull request updates the `Comment.java` file to improve code quality and security. Changes include modifying variable names for consistency, changing public fields to private, using try-with-resources for database operations, and improving logging.

**Summary:** 
- **File Modified:** `src/main/java/com/scalesec/vulnado/Comment.java`
  - Changed public fields to private for encapsulation.
  - Renamed `created_on` to `createdOn` for consistency.
  - Used try-with-resources for `Statement` and `PreparedStatement` to ensure proper resource management.
  - Improved logging by using `Logger` instead of `System.err.println`.
  - Corrected method names to follow camelCase convention (`fetch_all` to `fetchAll`).

**Recommendation:** 
- Ensure that all public fields are changed to private to maintain encapsulation.
- Verify that all database connections are properly closed to prevent resource leaks.
- Consider adding more detailed logging for better traceability.
- Review the exception handling to ensure that all potential exceptions are properly managed.

**Explanation of vulnerabilities:** 
- **Resource Leak:** The original code did not use try-with-resources, which could lead to resource leaks if exceptions occur. The updated code uses try-with-resources to ensure that `Statement` and `PreparedStatement` are properly closed.
  ```java
  try (Statement stmt = cxn.createStatement()) {
      // code
  }
  ```
- **Logging:** The original code used `System.err.println` for logging errors, which is not recommended for production code. The updated code uses `Logger` for better logging practices.
  ```java
  Logger logger = Logger.getLogger(Comment.class.getName());
  logger.severe(e.getClass().getName() + ": " + e.getMessage());
  ```

