### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,19 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 50e54dc9b7c7568b46c2536742f4901f8b7713fd

**Description:** The pull request updates the `LinksController.java` file to specify the HTTP method for the `@RequestMapping` annotations and removes some unused imports.

**Summary:**
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinksController.java`
  - **Changes:**
    - Removed unused imports: `org.springframework.boot.*`, `org.springframework.http.HttpStatus`, and `java.io.Serializable`.
    - Added `method = RequestMethod.GET` to the `@RequestMapping` annotations for the `/links` and `/links-v2` endpoints to explicitly specify that these endpoints should handle GET requests.

**Recommendation:** 
- Ensure that the removal of the unused imports does not affect any other parts of the application. 
- Verify that the endpoints `/links` and `/links-v2` are intended to handle only GET requests. If other HTTP methods are required, they should be specified accordingly.

**Explanation of vulnerabilities:**
- **Potential Vulnerability:** The `@RequestParam String url` parameter in both methods could be susceptible to URL injection attacks if not properly validated.
- **Suggested Correction:**
  - Validate the `url` parameter to ensure it is a well-formed URL and does not contain any malicious content.
  - Example of validation:
    ```java
    import java.net.MalformedURLException;
    import java.net.URL;

    List<String> links(@RequestParam String url) throws IOException {
        try {
            new URL(url); // Validate URL format
        } catch (MalformedURLException e) {
            throw new BadRequest("Invalid URL format");
        }
        return LinkLister.getLinks(url);
    }
    ```

This ensures that the `url` parameter is a valid URL and helps prevent potential security issues related to URL injection.