### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -7,12 +7,13 @@ import org.jsoup.select.Elements;
 import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
+import java.util.logging.Logger;
 import java.net.*;
 
 
-public class LinkLister {
+public class LinkLister { private LinkLister() { }
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +26,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      Logger logger = Logger.getLogger(LinkLister.class.getName()); logger.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 5dda1a468185cfff6d9709c403b81be30b1b6d26

**Description:** The pull request updates the `LinkLister.java` file to improve code quality and logging practices. It includes the addition of a logger, removal of redundant type declarations, and the introduction of a private constructor to prevent instantiation.

**Summary:** 
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinkLister.java`
  - **Added:** `import java.util.logging.Logger;` to include logging functionality.
  - **Modified:** `public class LinkLister { private LinkLister() { }` to prevent instantiation of the class.
  - **Modified:** `List<String> result = new ArrayList<String>();` to `List<String> result = new ArrayList<>();` for type inference.
  - **Modified:** `System.out.println(host);` to `Logger logger = Logger.getLogger(LinkLister.class.getName()); logger.info(host);` to use logging instead of standard output.

**Recommendation:** 
- Ensure that the logger is properly configured to handle different logging levels and output destinations.
- Consider adding more detailed logging messages to provide better context for debugging.
- Review the usage of `Logger` to ensure it adheres to best practices, such as avoiding excessive logging and ensuring sensitive information is not logged.

**Explanation of vulnerabilities:** 
- **Potential Vulnerability:** The logging of the host information could expose sensitive data if not handled properly.
  - **Correction Suggestion:** Ensure that the logger configuration does not log sensitive information in production environments. Use appropriate logging levels and filters to manage what gets logged.
  ```java
  Logger logger = Logger.getLogger(LinkLister.class.getName());
  if (!host.startsWith("172.") && !host.startsWith("192.168") && !host.startsWith("10.")) {
      logger.info("Host: " + host);
  }
  ```

