### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,19 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the dade8a77afbafc4d5a234468cc4bbaba048242d1

**Description:** The pull request updates the `LinksController.java` file to specify the HTTP method for the `@RequestMapping` annotations and removes unused imports.

**Summary:**
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinksController.java`
  - Removed unused imports: `org.springframework.boot.*`, `org.springframework.http.HttpStatus`, `java.io.Serializable`.
  - Added `method = RequestMethod.GET` to the `@RequestMapping` annotations for the `/links` and `/links-v2` endpoints to explicitly specify that these endpoints should handle GET requests.

**Recommendation:** 
- Ensure that the removal of the imports does not affect other parts of the codebase. It is good practice to remove unused imports to keep the code clean and maintainable.
- Verify that the endpoints `/links` and `/links-v2` are intended to handle only GET requests. If other HTTP methods are required, adjust the `method` attribute accordingly.

**Explanation of vulnerabilities:**
- No specific vulnerabilities were introduced or fixed in this pull request. However, specifying the HTTP method in the `@RequestMapping` annotation improves the clarity and security of the code by explicitly defining the allowed HTTP methods for the endpoints. This can help prevent unintended behavior and potential security issues related to handling unexpected HTTP methods.