### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,19 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 8c5a12db61098c7b02222d9bb84c064f1dee10c6

**Description:** The pull request updates the `LinksController.java` file to specify the HTTP method for the `@RequestMapping` annotations. The `method` attribute is added to both `@RequestMapping` annotations to explicitly define them as GET requests.

**Summary:** 
- File: `src/main/java/com/scalesec/vulnado/LinksController.java` (modified)
  - Removed unused imports: `org.springframework.boot.*`, `org.springframework.http.HttpStatus`, `java.io.Serializable`
  - Added `method = RequestMethod.GET` to `@RequestMapping` annotations for `/links` and `/links-v2` endpoints.

**Recommendation:** 
- Ensure that the removal of unused imports does not affect other parts of the codebase. It is good practice to keep the code clean and free of unnecessary imports.
- Verify that the endpoints `/links` and `/links-v2` are intended to be GET requests. If other HTTP methods are required, they should be specified accordingly.
- Consider adding unit tests to verify the behavior of the endpoints after the changes.

**Explanation of vulnerabilities:** 
- No specific vulnerabilities were introduced or fixed in this pull request. However, specifying the HTTP method explicitly can help prevent unintended behavior and improve the clarity of the code.
- Ensure that the `url` parameter is properly validated to prevent potential security issues such as URL injection attacks. For example:

```java
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
List<String> links(@RequestParam String url) throws IOException {
    if (!isValidUrl(url)) {
        throw new IllegalArgumentException("Invalid URL");
    }
    return LinkLister.getLinks(url);
}

private boolean isValidUrl(String url) {
    // Implement URL validation logic here
    return true; // Placeholder
}
```

This validation can help mitigate security risks associated with accepting user input directly.