### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -14,28 +14,28 @@ public class CommentsController {
   private String secret;
 
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
     return Comment.create(input.username, input.body);
   }
 
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  private String username;
+  private String body;
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 69b26cf82d085c68138faa0c3c1b65cb4ac7900d

**Description:** The pull request updates the `CommentsController.java` file to use more specific annotations for HTTP methods and modifies the `CommentRequest` class to use private fields instead of public ones.

**Summary:** 
- **File Modified:** `src/main/java/com/scalesec/vulnado/CommentsController.java`
  - **Changes:**
    - Replaced `@RequestMapping` annotations with more specific annotations: `@GetMapping`, `@PostMapping`, and `@DeleteMapping`.
    - Changed the visibility of `username` and `body` fields in the `CommentRequest` class from public to private.

**Recommendation:** 
- Ensure that getter and setter methods are added for the `username` and `body` fields in the `CommentRequest` class to maintain encapsulation and allow access to these fields.
- Verify that the changes to the annotations do not affect the functionality of the endpoints and that they are correctly mapped.

**Explanation of vulnerabilities:** 
- **Potential Vulnerability:** Changing the visibility of fields to private without providing access methods can lead to issues with serialization and deserialization, especially if these fields are expected to be accessed by other parts of the code.
  - **Correction Suggestion:**
    ```java
    class CommentRequest implements Serializable {
      private String username;
      private String body;

      public String getUsername() {
        return username;
      }

      public void setUsername(String username) {
        this.username = username;
      }

      public String getBody() {
        return body;
      }

      public void setBody(String body) {
        this.body = body;
      }
    }
    ```
- **Security Improvement:** The `@CrossOrigin(origins = "*")` annotation allows requests from any origin, which can be a security risk. Consider specifying allowed origins or using more secure CORS configurations.

