### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,6 +1,5 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 2377cc05280e2d1843ce59090b58ef3b70cc7ed7

**Description:** The pull request modifies the `LinksController.java` file by removing an unused import statement. This is a minor cleanup to improve code quality and maintainability.

**Summary:** 
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinksController.java`
- **Change Description:** 
  - Removed the unused import statement: `import org.springframework.boot.*;`
  - No functional changes were made to the code. This is purely a code cleanup to remove unnecessary imports.

**Recommendation:** 
- Removing unused imports is a good practice as it helps to keep the code clean and reduces potential confusion for developers. However, it is recommended to:
  1. Use an automated tool or IDE feature to identify and remove unused imports across the entire project to ensure consistency.
  2. Add a comment in the pull request description to clarify that this change is a non-functional cleanup for better transparency.

**Explanation of vulnerabilities:** 
- No vulnerabilities were introduced or fixed in this change. 
- Removing unused imports does not affect the functionality or security of the application. However, it is always good to ensure that no critical imports are accidentally removed. In this case, the removed import (`org.springframework.boot.*`) was not used anywhere in the file, so this change is safe.

